### PR TITLE
Allow enabling std implementation for wasm target family

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "critical-section"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 edition = "2018"
 description = "Critical section abstraction"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ cfg_if::cfg_if! {
                 cortex_m::interrupt::enable()
             }
         }
-    } else if #[cfg(any(unix, windows))] {
+    } else if #[cfg(any(unix, windows, wasm))] {
         extern crate std;
         static INIT: std::sync::Once = std::sync::Once::new();
         static mut GLOBAL_LOCK: Option<std::sync::Mutex<()>> = None;


### PR DESCRIPTION
On platforms like WASM, lots of std is available, but needs to be explicitly enabled. Having a std flag would allow reusing the std impl for such platforms.