### PR TITLE
Support AVR (Arduino) platform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(llvm_asm)]
 
 pub use bare_metal::CriticalSection;
 
@@ -90,6 +91,25 @@ cfg_if::cfg_if! {
         unsafe fn _critical_section_release(token: u8) {
             if token != 0 {
                 cortex_m::interrupt::enable()
+            }
+        }
+    } else if #[cfg(target_arch = "avr")] {
+        #[no_mangle]
+        unsafe fn _critical_section_acquire() -> u8 {
+            let mut sreg: u8;
+            llvm_asm!(
+                "in $0, 0x3F
+                 cli"
+                : "=r"(sreg)
+                ::: "volatile"
+            );
+            sreg
+        }
+
+        #[no_mangle]
+        unsafe fn _critical_section_release(token: u8) {
+            if token & 0x80 == 0x80 {
+                llvm_asm!("sei" :::: "volatile");
             }
         }
     } else if #[cfg(target_arch = "riscv32")] {


### PR DESCRIPTION
This commit adds support for AVR (Arduino) platforms via the
`avr-device` crate. Due to the nature of the AVR platform & `avr-device`
crate, board-specific features from `avr-device` are re-exported here.

The underlying motivation for this support is to enable further
integration with the greater Embedded Rust ecosystem. As an example,
`embedded-nal` depends upon `heapless`, which in turn depends upon
atomic support, either natively or via `atomic-polyfill`.
`atomic-polyfill` uses `critical-section`, and so enabling AVR support
in this crate has great benefits to the downstream packages that have
come to depend upon `critical-section`.

`avr-device` was adapted to provide `critical-section`-compatible
interrupt semantics in Rahix/avr-device#89, which was released in `avr-device` `v0.3.2`.

To test compilation against this feature, you would use a compatible target JSON
specification (several are available [here](https://github.com/Rahix/avr-hal-template/tree/main/avr-specs)), and enable the corresponding feature.

Example:
```
cargo build --target avr-specs/avr-atmega2560.json --features avr-atmega2560
```