### PR TITLE
Remove Cortex-M implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,21 +20,6 @@ custom-impl = []
 bare-metal = "1.0.0"
 cfg-if = "1.0.0"
 
-[target.thumbv6m-none-eabi.dependencies]
-cortex-m = "0.7.2"
-[target.thumbv7em-none-eabi.dependencies]
-cortex-m = "0.7.2"
-[target.thumbv7em-none-eabihf.dependencies]
-cortex-m = "0.7.2"
-[target.thumbv7m-none-eabi.dependencies]
-cortex-m = "0.7.2"
-[target."thumbv8m.base-none-eabi".dependencies]
-cortex-m = "0.7.2"
-[target."thumbv8m.main-none-eabi".dependencies]
-cortex-m = "0.7.2"
-[target."thumbv8m.main-none-eabihf".dependencies]
-cortex-m = "0.7.2"
-
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv = {version = "0.7.0"}
 

--- a/ci.sh
+++ b/ci.sh
@@ -6,7 +6,7 @@ rustup toolchain install nightly-2021-01-07 --component rust-src
 cargo +nightly-2021-01-07 build -Zbuild-std=core --target avr-specs/avr-atmega328p.json
 
 cargo build
-cargo build --target thumbv6m-none-eabi
-cargo build --target thumbv7em-none-eabi
+cargo build --features custom-impl --target thumbv6m-none-eabi
+cargo build --features custom-impl --target thumbv7em-none-eabi
 cargo build --target riscv32imc-unknown-none-elf
 cargo build --target riscv32imac-unknown-none-elf

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,19 +107,7 @@ cfg_if::cfg_if! {
             };
         }
     } else if #[cfg(cortex_m)] {
-        #[no_mangle]
-        unsafe fn _critical_section_acquire() -> u8 {
-            let primask = cortex_m::register::primask::read();
-            cortex_m::interrupt::disable();
-            primask.is_active() as _
-        }
-
-        #[no_mangle]
-        unsafe fn _critical_section_release(token: u8) {
-            if token != 0 {
-                cortex_m::interrupt::enable()
-            }
-        }
+      compile_error!("Critical section is not implemented for this target. You may need to supply a custom critical section implementation with the `custom-impl` feature or activate the `single-core-critical-section` feature of the `cortex-m` crate if you're targeting a single-core Cortex-M system.");
     } else if #[cfg(target_arch = "avr")] {
         #[no_mangle]
         unsafe fn _critical_section_acquire() -> u8 {


### PR DESCRIPTION
This implementation is wrong on multicore systems. Also, we want to implement the single-core implementation directly  in the `cortex-m` crate, so we need to remove the circular dependency for that as well.

See https://github.com/rust-embedded/cortex-m/pull/433.

