### PR TITLE
Add `loom` support to `std` critical section implementation

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,6 +18,10 @@ jobs:
             features: ''
           - rust: 1.63
             features: 'std'
+          - rust: 1.73
+            features: 'std'
+            cfgs: "--cfg loom"
+
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
@@ -27,4 +31,4 @@ jobs:
             components: clippy
             override: true
       - name: Clippy check
-        run: cargo clippy --features "${{matrix.features}}"
+        run: RUSTFLAGS="${{matrix.cfgs}}" cargo clippy --features "${{matrix.features}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,12 @@ jobs:
             features: ''
           - rust: 1.63
             features: 'std'
+          - rust: 1.73
+            features: 'std'
+            cfgs: "--cfg loom"
+            # Lib tests are the only relevant & working ones
+            # for loom.
+            extra_flags: "--lib"
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
@@ -27,4 +33,4 @@ jobs:
             components: clippy
             override: true
       - name: Test
-        run: cargo test --features "${{matrix.features}}"
+        run: RUSTFLAGS="${{matrix.cfgs}}" cargo test --features "${{matrix.features}}" ${{matrix.extra_flags}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,9 @@ restore-state-u16 = []
 restore-state-u32 = []
 restore-state-u64 = []
 restore-state-usize = []
+
+[target.'cfg(loom)'.dependencies]
+loom = "0.7.2"
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(loom)'] }

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ provide an implementation based on `std::sync::Mutex`, so you don't have to add 
 critical-section = { version = "1.1", features = ["std"]}
 ```
 
+## Usage in [`loom`] tests
+
+`critical-section` supports [`loom`] by enabling the `std` feature and passing `--cfg loom` as `RUSTFLAGS` (either through `.cargo/config.toml`, or through the environment variable).
+This implementation is identical to the normal `std` implementation, but uses `loom` synchronization primitives instead.
+
+[`loom`]: https://docs.rs/loom/latest/loom/#writing-tests
+
 ## Usage in libraries
 
 If you're writing a library intended to be portable across many targets, simply add a dependency on `critical-section`
@@ -219,6 +226,7 @@ This crate is guaranteed to compile on the following Rust versions:
 
 - If the `std` feature is not enabled: stable Rust 1.54 and up.
 - If the `std` feature is enabled: stable Rust 1.63 and up.
+- If the `std` feature and `--cfg loom` are enabled: stable Rust 1.73 and up.
 
 It might compile with older versions but that may change in any new patch release.
 


### PR DESCRIPTION
[`loom`] is a tool that can be used to validate concurrent programs exhaustively.

This PR adds support for `loom` to the `std` implementation of `critical-section`, with the `loom`-suggested approach of using a `cfg` for it. It raises the MSRV of this project to 1.73 when `--cfg loom` is specified, but otherwise does not affect it.

An example use-case for finding problems using `loom` can be found [here]. It uses the same critical section implementation as is provided here. Without it, `loom` assumes that there are no synchronization/interruption points when a critical section starts or ends. With `loom`, it runs all the concurrent permutations, and allowed us to repro (though we should've been using `loom` preventatively) a concurrency bug. 

[here]: https://github.com/rtic-rs/rtic/pull/1027
[`loom`]: https://docs.rs/loom